### PR TITLE
Support Ruby 3 keyword argument forwarding in PageManager#method_missing

### DIFF
--- a/lib/qat/web/page_manager.rb
+++ b/lib/qat/web/page_manager.rb
@@ -61,10 +61,14 @@ module QAT::Web
 
 
     #Forwards all methods to current page.
-    def method_missing method, *args, &block
-      result = @current_page.send method, *args, &block
+    def method_missing(method, *args, **kwargs, &block)
+      result        = @current_page.send(method, *args, **kwargs, &block)
       @current_page = result if @current_page.class.actions.include? method
-      return result
+      result
+    end
+
+    def respond_to_missing?(method, include_private = false)
+      @current_page.respond_to?(method, include_private) || super
     end
 
   end

--- a/lib/qat/web/version.rb
+++ b/lib/qat/web/version.rb
@@ -4,6 +4,6 @@ module QAT
 #@since 1.0.0
   module Web
     # Represents QAT-Web's version
-    VERSION = '9.0.6'
+    VERSION = '9.0.7'
   end
 end

--- a/qat-web.gemspec
+++ b/qat-web.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name        = 'qat-web'
-  gem.version     = '9.0.6'
+  gem.version     = '9.0.7'
   gem.summary     = %q{QAT-Web is a browser controller for Web testing}
   gem.description = <<-DESC
   QAT-Web is a browser controller for Web testing, with support for various browsers and webdrivers.


### PR DESCRIPTION
fix: support Ruby 3 keyword argument forwarding in PageManager#method_missing

Ruby 3 no longer automatically converts a Hash to keyword arguments.
The previous implementation of method_missing only forwarded *args, causing methods with keyword parameters to raise:
ArgumentError: wrong number of arguments

This change adds **kwargs to properly forward keyword arguments.